### PR TITLE
feature/Register-Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ O projeto LiteraSpring adota uma arquitetura modular e organizada, com separaç�
    │   ├── ...
    │
    ├── config               # Configurações globais da aplicação
-   │   ├── security         # Configurações de segurança (ex: autenticação, autorização)
+   │   ├── aop              # Configurações do AOP
    │
    ├── domain               # Camada de domínio, contendo entidades, enums e repositórios
    │   ├── book             # Entidade livro, enums e repositório

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 LiteraSpring é uma API RESTful desenvolvida com Spring Boot para gerenciamento de livros. O sistema permite o controle de livros, autores, gêneros literários, tradutores, sagas literárias, entre outras informações, visando oferecer uma base sólida e escalável para aplicações de gerenciamento bibliotecário.
 
 Este projeto é ideal para fins acadêmicos e práticos, ilustrando boas práticas de arquitetura, organização de código e utilização do ecossistema Spring.
-
 ## ⚙️ Tecnologias utilizadas
 - Java 17+
 - Spring Boot 3.4.4
@@ -12,7 +11,6 @@ Este projeto é ideal para fins acadêmicos e práticos, ilustrando boas prátic
 - PostgreSQL
 - Maven
 - IntelliJ IDEA (recomendado)
-
 ## 📦 Instalação e execução local
 
 ### Pré-requisitos
@@ -39,8 +37,8 @@ Antes de começar, você vai precisar ter instalado:
    
     No arquivo `src/main/resources/application.properties`, configure o acesso ao PostgreSQL com as informações corretas:
     ```properties
-    spring.datasource.url=jdbc:postgresql://localhost:5432/literaspring
-    spring.datasource.username=seu_usuario
+    spring.datasource.url=jdbc:postgresql://localhost:5432/nomeBancoDeDado
+    spring.datasource.username=seu_usuário
     spring.datasource.password=sua_senha
     spring.jpa.hibernate.ddl-auto=update
     spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
@@ -55,60 +53,72 @@ Antes de começar, você vai precisar ter instalado:
     ```
    Ou diretamente pelo IntelliJ IDEA clicando no botão de run na classe principal `LiteraSpringApplication`.
 
-
 6. Acesse o sistema:
 
     A aplicação estará disponível em: http://localhost:8080
-
 ## 📚 Objetivos do projeto
 Este projeto tem como objetivos principais:
 - Servir como base para estudo e prática com Spring Boot 
 - Demonstrar arquitetura limpa e modular 
 - Aplicar conceitos de Engenharia de Software (design, documentação, testes)
+## ✨ Funcionalidades implementadas
+- CRUD completo de entidades: Livro, Autor, Gênero Literário, Tradutor e Saga Literária.
+- Arquitetura em camadas com separação por contexto (bounded context).
+- Mapeamento entre entidades e DTOs com camada de mapeamento dedicada.
+- Validações padrão com Bean Validation (@NotBlank, @Size, etc.).
+- Anotações personalizadas para transformação de campos de texto:
+   - `@UpperTrim`: remove espaços e converte para letras maiúsculas. 
+   - `@TrimOnly`: remove espaços em branco antes/depois do texto.
 
+Essas anotações utilizam programação orientada a aspectos (AOP) para aplicar as transformações de forma transparente e desacoplada, garantindo limpeza de dados antes da persistência ou do uso no sistema.
 ## 🧱 Estrutura de pacotes
 O projeto LiteraSpring adota uma arquitetura modular e organizada, com separação clara entre as camadas da aplicação. A seguir, a estrutura de pacotes do projeto:
-
-```css
-com.guarino.literaspringapi
-│
-├── application          # Camada de aplicação, contém regras de negócio e serviços (use cases)
-│   ├── book             # Funcionalidade de livros (DTOs, services, mappers, exceptions)
-│   ├── author           # Funcionalidade de autores
-│   ├── genre            # Funcionalidade de gêneros literários
-│   ├── saga             # Funcionalidade de sagas literárias
-│   ├── translator       # Funcionalidade de tradutores
-│   ├── ...
-│
-├── config               # Configurações globais da aplicação
-│   ├── security         # Configurações de segurança (ex: autenticação, autorização)
-│
-├── domain               # Camada de domínio, contendo entidades, enums e repositórios
-│   ├── book             # Entidade livro, enums e repositório
-│   ├── author           # Entidade autor
-│   ├── genre            # Entidade gênero
-│   ├── saga             # Entidade saga
-│   ├── translator       # Entidade tradutor
-│   ├── ...
-│
-├── infrastructure       # Integrações externas e infraestrutura da aplicação
-│   ├── aws              # Integração com serviços da AWS
-│   │   ├── rds          # Configurações e integração com RDS (banco de dados)
-│   │   ├── s3           # Integração com Amazon S3 (armazenamento de arquivos)
-│   ├── persistence      # Implementações específicas de persistência (caso necessário)
-│
-├── presentation         # Camada de apresentação (controllers/rest APIs)
-│   ├── book             # Controlador de livros
-│   ├── author           # Controlador de autores
-│   ├── genre            # Controlador de gêneros
-│   ├── saga             # Controlador de sagas
-│   ├── translator       # Controlador de tradutores
-│   ├── ...
-│
-├── shared               # Utilitários e componentes reutilizáveis em todo o projeto
-│   ├── exception        # Exceções globais
-│   ├── handler          # Manipuladores globais de exceção (ex: @ControllerAdvice)
-│   ├── dto              # DTOs genéricos
-│   ├── validation       # Anotações e lógicas de validação customizadas
-│   ├── util             # Classes utilitárias (ex: manipuladores de datas, strings, etc.)
+```text
+   com.guarino.literaspringapi
+   │
+   ├── application          # Camada de aplicação, contém regras de negócio e serviços (use cases)
+   │   ├── book             # Funcionalidade de livros (DTOs, services, mappers, exceptions)
+   │   ├── author           # Funcionalidade de autores
+   │   ├── genre            # Funcionalidade de gêneros literários
+   │   ├── saga             # Funcionalidade de sagas literárias
+   │   ├── translator       # Funcionalidade de tradutores
+   │   ├── ...
+   │
+   ├── config               # Configurações globais da aplicação
+   │   ├── security         # Configurações de segurança (ex: autenticação, autorização)
+   │
+   ├── domain               # Camada de domínio, contendo entidades, enums e repositórios
+   │   ├── book             # Entidade livro, enums e repositório
+   │   ├── author           # Entidade autor
+   │   ├── genre            # Entidade gênero
+   │   ├── saga             # Entidade saga
+   │   ├── translator       # Entidade tradutor
+   │   ├── ...
+   │
+   ├── infrastructure       # Integrações externas e infraestrutura da aplicação
+   │   ├── aws              # Integração com serviços da AWS
+   │   │   ├── rds          # Configurações e integração com RDS (banco de dados)
+   │   │   ├── s3           # Integração com Amazon S3 (armazenamento de arquivos)
+   │   ├── persistence      # Implementações específicas de persistência (caso necessário)
+   │
+   ├── presentation         # Camada de apresentação (controllers/rest APIs)
+   │   ├── book             # Controlador de livros
+   │   ├── author           # Controlador de autores
+   │   ├── genre            # Controlador de gêneros
+   │   ├── saga             # Controlador de sagas
+   │   ├── translator       # Controlador de tradutores
+   │   ├── ...
+   │
+   ├── shared               # Utilitários e componentes reutilizáveis em todo o projeto
+   │   ├── exception        # Exceções globais
+   │   ├── handler          # Manipuladores globais de exceção (ex: @ControllerAdvice)
+   │   ├── dto              # DTOs genéricos
+   │   ├── validation       # Anotações e lógicas de validação customizadas
+   │   ├── util             # Classes utilitárias (ex: manipuladores de datas, strings, etc.)
 ```
+## 🧪 Testes
+O projeto está sendo estruturado para suportar testes unitários e de integração. Os testes de integração utilizarão um banco separado via application-test.properties, permitindo verificar a integridade dos fluxos completos e a proteção contra falhas como SQL Injection.
+## 🔄 Próximos passos
+- Criação de testes automatizados (JUnit 5 + Testcontainers ou banco embarcado)
+- Validações mais sofisticadas com ConstraintValidator
+- Paginação, ordenação e filtros nos endpoints

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
@@ -1,12 +1,66 @@
 package com.guarino.literaspringapi.application.publisher.dto;
 
+import com.guarino.literaspringapi.shared.validation.TrimOnly;
+import com.guarino.literaspringapi.shared.validation.UpperTrim;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record PublisherRequestDTO(
-        @NotBlank @Size(max = 150) String name,
-        @Size(max = 10) String foundationData,
-        @Size(max = 700) String description,
-        @Size(max = 150) String email,
-        @Size(max = 100) String countryHeadquarter
-){}
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PublisherRequestDTO {
+
+        @NotBlank(message = "O nome não pode ser vazio ou nulo.")
+        @Size(max = 150, message = "O nome precisa ter no máximo 150 caracteres.")
+        @UpperTrim
+        private String name;
+
+        @Pattern(
+                regexp = "^\\d{4}-\\d{2}-\\d{2}$",
+                message = "A data deve estar no formato yyyy-MM-dd."
+        )
+        @Size(max = 10)
+        @TrimOnly
+        private String foundationData;
+
+        @Size(max = 700, message = "A descrição precisa ter no máximo 700 caracteres.")
+        @TrimOnly
+        private String description;
+
+        @Pattern(
+                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+                message = "Formato de e-mail inválido."
+        )
+        @Size(max = 150)
+        @UpperTrim
+        private String email;
+
+        @Pattern(
+                regexp = "^(https?://)?(www\\.)?[a-zA-Z0-9\\-]+(\\.[a-zA-Z]{2,}){1,}(/.*)?$",
+                message = "O site deve ser uma URL válida."
+        )
+        @Size(max = 200)
+        @UpperTrim
+        private String website;
+
+        @Size(max = 20)
+        @UpperTrim
+        private String taxId;
+
+        @Pattern(
+                regexp = "^[0-9]{8,15}$",
+                message = "O número de telefone deve conter apenas dígitos (sem espaços, traços ou símbolos) e ter entre 8 e 15 dígitos."
+        )
+        @Size(max = 15)
+        @TrimOnly
+        private String telephone;
+
+}
+

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
@@ -2,14 +2,15 @@ package com.guarino.literaspringapi.application.publisher.dto;
 
 import com.guarino.literaspringapi.shared.validation.TrimOnly;
 import com.guarino.literaspringapi.shared.validation.UpperTrim;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
 
 @Getter
 @Setter
@@ -42,7 +43,7 @@ public class PublisherRequestDTO {
         private String email;
 
         @Pattern(
-                regexp = "(?i)^(https?://)?(www\\.)?[a-zA-Z0-9\\-]+(\\.[a-zA-Z]{2,}){1,}(/.*)?$",
+                regexp = "(?i)^(https?://)?(www\\.)?[a-zA-Z0-9\\-]+(\\.[a-zA-Z]{2,})+(/.*)?$",
                 message = "O site deve ser uma URL válida."
         )
         @Size(max = 200)
@@ -64,6 +65,5 @@ public class PublisherRequestDTO {
         @Size(max = 15)
         @TrimOnly
         private String telephone;
-
 }
 

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
@@ -17,8 +17,8 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PublisherRequestDTO {
 
-        @NotBlank(message = "O nome não pode ser vazio ou nulo.")
-        @Size(max = 150, message = "O nome precisa ter no máximo 150 caracteres.")
+        @NotBlank(message = "O nome deve ser informado.")
+        @Size(max = 150, min = 3, message = "O nome precisa ter no máximo 150 caracteres e no mínimo 3 caracteres.")
         @UpperTrim
         private String name;
 
@@ -35,7 +35,7 @@ public class PublisherRequestDTO {
         private String description;
 
         @Pattern(
-                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+                regexp = "(?i)^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
                 message = "Formato de e-mail inválido."
         )
         @Size(max = 150)
@@ -43,13 +43,17 @@ public class PublisherRequestDTO {
         private String email;
 
         @Pattern(
-                regexp = "^(https?://)?(www\\.)?[a-zA-Z0-9\\-]+(\\.[a-zA-Z]{2,}){1,}(/.*)?$",
+                regexp = "(?i)^(https?://)?(www\\.)?[a-zA-Z0-9\\-]+(\\.[a-zA-Z]{2,}){1,}(/.*)?$",
                 message = "O site deve ser uma URL válida."
         )
         @Size(max = 200)
         @UpperTrim
         private String website;
 
+        @Pattern(
+                regexp = "^[0-9]{5,20}$",
+                message = "O identificador fiscal deve conter apenas números (mínimo 5 e máximo 20 dígitos), sem formatação."
+        )
         @Size(max = 20)
         @UpperTrim
         private String taxId;

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
@@ -28,7 +28,7 @@ public class PublisherRequestDTO {
         )
         @Size(max = 10)
         @TrimOnly
-        private String foundationData;
+        private String foundationDate;
 
         @Size(max = 700, message = "A descrição precisa ter no máximo 700 caracteres.")
         @TrimOnly

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
@@ -51,8 +51,8 @@ public class PublisherRequestDTO {
         private String website;
 
         @Pattern(
-                regexp = "^[0-9]{5,20}$",
-                message = "O identificador fiscal deve conter apenas números (mínimo 5 e máximo 20 dígitos), sem formatação."
+                regexp = "^[A-Za-z0-9]{5,20}$",
+                message = "O identificador fiscal deve conter apenas letras e números, sem espaços ou símbolos, entre 5 e 20 caracteres."
         )
         @Size(max = 20)
         @UpperTrim

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherRequestDTO.java
@@ -27,7 +27,6 @@ public class PublisherRequestDTO {
                 message = "A data deve estar no formato yyyy-MM-dd."
         )
         @Size(max = 10)
-        @TrimOnly
         private String foundationDate;
 
         @Size(max = 700, message = "A descrição precisa ter no máximo 700 caracteres.")

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherResponseDTO.java
@@ -2,12 +2,15 @@ package com.guarino.literaspringapi.application.publisher.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record PublisherResponseDTO(
         @NotNull String idPublisher,
-        @NotBlank String name,
-        String foundation_data,
-        String description,
-        String email,
-        String country_headquarter
+        @NotBlank @Size(max = 150) String name,
+        @Size(max = 10) String foundationData,
+        @Size(max = 700) String description,
+        @Size(max = 150) String email,
+        @Size(max = 200) String website,
+        @Size(max = 20) String taxId,
+        @Size(max = 15) String telephone
 ){}

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/dto/PublisherResponseDTO.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 public record PublisherResponseDTO(
         @NotNull String idPublisher,
         @NotBlank @Size(max = 150) String name,
-        @Size(max = 10) String foundationData,
+        @Size(max = 10) String foundationDate,
         @Size(max = 700) String description,
         @Size(max = 150) String email,
         @Size(max = 200) String website,

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/mapper/PublisherMapper.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/mapper/PublisherMapper.java
@@ -3,6 +3,7 @@ package com.guarino.literaspringapi.application.publisher.mapper;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
+
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/mapper/PublisherMapper.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/mapper/PublisherMapper.java
@@ -15,18 +15,21 @@ public class PublisherMapper {
                 publisher.getFoundationDate(),
                 publisher.getDescription(),
                 publisher.getEmail(),
-                publisher.getCountryHeadquarter()
+                publisher.getWebsite(),
+                publisher.getTaxId(),
+                publisher.getTelephone()
         );
     }
 
     public Publisher toEntity(PublisherRequestDTO publisherRequestDTO) {
         return new Publisher(
-                null,
-                publisherRequestDTO.name().toUpperCase(),
-                publisherRequestDTO.foundationData().toUpperCase(),
-                publisherRequestDTO.description().toUpperCase(),
-                publisherRequestDTO.email().toUpperCase(),
-                publisherRequestDTO.countryHeadquarter().toUpperCase()
+                publisherRequestDTO.getName(),
+                publisherRequestDTO.getFoundationData(),
+                publisherRequestDTO.getDescription(),
+                publisherRequestDTO.getEmail(),
+                publisherRequestDTO.getWebsite(),
+                publisherRequestDTO.getTelephone(),
+                publisherRequestDTO.getTaxId()
         );
     }
 }

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/mapper/PublisherMapper.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/mapper/PublisherMapper.java
@@ -24,7 +24,7 @@ public class PublisherMapper {
     public Publisher toEntity(PublisherRequestDTO publisherRequestDTO) {
         return new Publisher(
                 publisherRequestDTO.getName(),
-                publisherRequestDTO.getFoundationData(),
+                publisherRequestDTO.getFoundationDate(),
                 publisherRequestDTO.getDescription(),
                 publisherRequestDTO.getEmail(),
                 publisherRequestDTO.getWebsite(),

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/service/PublisherService.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/service/PublisherService.java
@@ -23,13 +23,6 @@ public class PublisherService {
 
     public PublisherResponseDTO createPublisher(PublisherRequestDTO request) {
 
-        if(!request.email().isEmpty() && publisherRepository.existsByEmail(request.email().toUpperCase()))
-            throw new ResourceAlreadyExistsException("Publisher", "email",  request.email());
-
-        if(publisherRepository.existsByNameAndFoundationDateAndCountryHeadquarter(request.name().toUpperCase(),
-                request.foundationData().toUpperCase(), request.countryHeadquarter().toUpperCase()))
-            throw new ResourceAlreadyExistsException("Publisher", "dados");
-
         var publisher = publisherMapper.toEntity(request);
         publisher = publisherRepository.save(publisher);
 

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/service/PublisherService.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/service/PublisherService.java
@@ -9,6 +9,8 @@ import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsExcepti
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.guarino.literaspringapi.shared.util.StringUtils.isNotBlank;
+
 @Service
 @Transactional
 public class PublisherService {
@@ -24,6 +26,19 @@ public class PublisherService {
     public PublisherResponseDTO createPublisher(PublisherRequestDTO request) {
 
         var publisher = publisherMapper.toEntity(request);
+
+        if(isNotBlank(publisher.getEmail()) && publisherRepository.existsByEmail(publisher.getEmail()))
+            throw new ResourceAlreadyExistsException("Editora", "email", publisher.getEmail());
+
+        if(isNotBlank(publisher.getTaxId()) && publisherRepository.existsByTaxId(publisher.getTaxId()))
+            throw new ResourceAlreadyExistsException("Editora", "identificador fiscal", publisher.getTaxId());
+
+        if(isNotBlank(publisher.getWebsite()) && publisherRepository.existsByWebsite(publisher.getWebsite()))
+            throw new ResourceAlreadyExistsException("Editora", "site", publisher.getWebsite());
+
+        if(isNotBlank(publisher.getTelephone()) && publisherRepository.existsByTelephone(publisher.getTelephone()))
+            throw new  ResourceAlreadyExistsException("Editora", "telefone", publisher.getTelephone());
+
         publisher = publisherRepository.save(publisher);
 
         return publisherMapper.toResponseDTO(publisher);

--- a/src/main/java/com/guarino/literaspringapi/application/publisher/service/PublisherService.java
+++ b/src/main/java/com/guarino/literaspringapi/application/publisher/service/PublisherService.java
@@ -4,8 +4,8 @@ import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO
 import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
 import com.guarino.literaspringapi.application.publisher.mapper.PublisherMapper;
 import com.guarino.literaspringapi.domain.publisher.repository.PublisherRepository;
-
 import com.guarino.literaspringapi.shared.util.UniquenessValidator;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,14 +29,12 @@ public class PublisherService {
 
     public PublisherResponseDTO createPublisher(PublisherRequestDTO request) {
         var publisher = publisherMapper.toEntity(request);
-
         uniquenessValidator.validateMultiple("Editora", Map.of(
                 "email", new UniquenessValidator.ValidationEntry(publisher.getEmail(), v -> publisherRepository.existsByEmail((String) v)),
                 "identificador fiscal", new UniquenessValidator.ValidationEntry(publisher.getTaxId(), v -> publisherRepository.existsByTaxId((String) v)),
                 "site", new UniquenessValidator.ValidationEntry(publisher.getWebsite(), v -> publisherRepository.existsByWebsite((String) v)),
                 "telefone", new UniquenessValidator.ValidationEntry(publisher.getTelephone(), v -> publisherRepository.existsByTelephone((String) v))
         ));
-
         publisher = publisherRepository.save(publisher);
         return publisherMapper.toResponseDTO(publisher);
     }

--- a/src/main/java/com/guarino/literaspringapi/config/aop/AopConfig.java
+++ b/src/main/java/com/guarino/literaspringapi/config/aop/AopConfig.java
@@ -1,0 +1,8 @@
+package com.guarino.literaspringapi.config.aop;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AopConfig {}

--- a/src/main/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspect.java
+++ b/src/main/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspect.java
@@ -36,28 +36,35 @@ public class FieldTransformationAspect {
 
         Field[] fields = obj.getClass().getDeclaredFields();
         for (Field field : fields) {
-            if (!field.getType().equals(String.class)) continue;
-
-            field.setAccessible(true);
-            try {
-                String value = (String) field.get(obj);
-                if (value == null) continue;
-
-                if (field.isAnnotationPresent(UpperTrim.class)) {
-                    String transformed = value.trim().toUpperCase();
-                    if (!transformed.equals(value)) {
-                        field.set(obj, transformed);
-                    }
-                } else if (field.isAnnotationPresent(TrimOnly.class)) {
-                    String transformed = value.trim();
-                    if (!transformed.equals(value)) {
-                        field.set(obj, transformed);
-                    }
-                }
-
-            } catch (IllegalAccessException e) {
-                logger.log(Level.SEVERE, "Erro ao acessar o campo: " + obj.getClass().getSimpleName() + "." + field.getName(), e);
+            if (field.getType().equals(String.class)) {
+                transformStringField(obj, field);
             }
         }
     }
+
+    private void transformStringField(Object obj, Field field) {
+        field.setAccessible(true);
+        try {
+            String value = (String) field.get(obj);
+            if (value != null && !value.trim().isEmpty()) {
+                String transformed = applyTransformation(field, value);
+                if (!transformed.equals(value)) {
+                    field.set(obj, transformed);
+                }
+            }
+        } catch (IllegalAccessException e) {
+            logger.log(Level.SEVERE, "Erro ao acessar o campo: " + obj.getClass().getSimpleName() + "." + field.getName(), e);
+        }
+    }
+
+    private String applyTransformation(Field field, String value) {
+        if (field.isAnnotationPresent(UpperTrim.class)) {
+            return value.trim().toUpperCase();
+        } else if (field.isAnnotationPresent(TrimOnly.class)) {
+            return value.trim();
+        } else {
+            return value;
+        }
+    }
 }
+

--- a/src/main/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspect.java
+++ b/src/main/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspect.java
@@ -2,10 +2,12 @@ package com.guarino.literaspringapi.config.aop;
 
 import com.guarino.literaspringapi.shared.validation.TrimOnly;
 import com.guarino.literaspringapi.shared.validation.UpperTrim;
+
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
+
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Field;
@@ -33,7 +35,6 @@ public class FieldTransformationAspect {
 
     private void transformFields(Object obj) {
         if (obj == null) return;
-
         Field[] fields = obj.getClass().getDeclaredFields();
         for (Field field : fields) {
             if (field.getType().equals(String.class)) {

--- a/src/main/java/com/guarino/literaspringapi/domain/publisher/entity/Publisher.java
+++ b/src/main/java/com/guarino/literaspringapi/domain/publisher/entity/Publisher.java
@@ -1,17 +1,18 @@
 package com.guarino.literaspringapi.domain.publisher.entity;
 
 import jakarta.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
 
-@Entity
-@Table(name = "publisher")
 @Getter
 @Setter
 @NoArgsConstructor
+@Entity
+@Table(name = "publisher")
 public class Publisher {
 
     @Id

--- a/src/main/java/com/guarino/literaspringapi/domain/publisher/entity/Publisher.java
+++ b/src/main/java/com/guarino/literaspringapi/domain/publisher/entity/Publisher.java
@@ -1,7 +1,6 @@
 package com.guarino.literaspringapi.domain.publisher.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +11,6 @@ import java.util.UUID;
 @Table(name = "publisher")
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
 public class Publisher {
 

--- a/src/main/java/com/guarino/literaspringapi/domain/publisher/entity/Publisher.java
+++ b/src/main/java/com/guarino/literaspringapi/domain/publisher/entity/Publisher.java
@@ -23,5 +23,23 @@ public class Publisher {
     private String foundationDate;
     private String description;
     private String email;
-    private String countryHeadquarter;
+    private String website;
+    private String telephone;
+    private String taxId;
+
+    public Publisher(String name,
+                     String foundationDate,
+                     String description,
+                     String email,
+                     String website,
+                     String telephone,
+                     String taxId) {
+        this.name = name;
+        this.foundationDate = foundationDate;
+        this.description = description;
+        this.email = email;
+        this.website = website;
+        this.telephone = telephone;
+        this.taxId = taxId;
+    }
 }

--- a/src/main/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepository.java
+++ b/src/main/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepository.java
@@ -7,4 +7,13 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface PublisherRepository extends JpaRepository<Publisher, UUID> {}
+public interface PublisherRepository extends JpaRepository<Publisher, UUID> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByTaxId(String taxId);
+
+    boolean existsByWebsite(String website);
+
+    boolean existsByTelephone(String telephone);
+}

--- a/src/main/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepository.java
+++ b/src/main/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepository.java
@@ -7,10 +7,4 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface PublisherRepository extends JpaRepository<Publisher, UUID> {
-
-    boolean existsByEmail(String email);
-
-    boolean existsByNameAndFoundationDateAndCountryHeadquarter(String name, String foundationDate, String countryHeadquarter);
-
-}
+public interface PublisherRepository extends JpaRepository<Publisher, UUID> {}

--- a/src/main/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepository.java
+++ b/src/main/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepository.java
@@ -1,10 +1,11 @@
 package com.guarino.literaspringapi.domain.publisher.repository;
 
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PublisherRepository extends JpaRepository<Publisher, UUID> {

--- a/src/main/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherController.java
+++ b/src/main/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherController.java
@@ -3,9 +3,11 @@ package com.guarino.literaspringapi.presentation.publisher.controller;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
 import com.guarino.literaspringapi.application.publisher.service.PublisherService;
-import jakarta.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 @Setter
@@ -19,7 +20,7 @@ public class ErrorResponseDTO {
 
     public ErrorResponseDTO(String errorType, String className, String message, String errorCode) {
         this.errorType = errorType;
-        this.timestamp = LocalDateTime.now().toString();
+        this.timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         this.className = className;
         this.message = message;
         this.errorCode = errorCode;

--- a/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
@@ -13,11 +13,13 @@ public class ErrorResponseDTO {
     private String timestamp;
     private String className;
     private String message;
+    private String errorCode;
 
-    public ErrorResponseDTO(String errorType, String className, String message) {
+    public ErrorResponseDTO(String errorType, String className, String message, String errorCode) {
         this.errorType = errorType;
         this.timestamp = LocalDateTime.now().toString();
         this.className = className;
         this.message = message;
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Getter
 @Setter
@@ -15,14 +16,14 @@ public class ErrorResponseDTO {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private String timestamp;
     private String className;
-    private String message;
+    private List<String> messages;
     private String errorCode;
 
-    public ErrorResponseDTO(String errorType, String className, String message, String errorCode) {
+    public ErrorResponseDTO(String errorType, String className, List<String> messages, String errorCode) {
         this.errorType = errorType;
         this.timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         this.className = className;
-        this.message = message;
+        this.messages = messages;
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
@@ -1,5 +1,6 @@
 package com.guarino.literaspringapi.shared.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 public class ErrorResponseDTO {
 
     private String errorType;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private String timestamp;
     private String className;
     private String message;

--- a/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/dto/ErrorResponseDTO.java
@@ -19,7 +19,10 @@ public class ErrorResponseDTO {
     private List<String> messages;
     private String errorCode;
 
-    public ErrorResponseDTO(String errorType, String className, List<String> messages, String errorCode) {
+    public ErrorResponseDTO(String errorType,
+                            String className,
+                            List<String> messages,
+                            String errorCode) {
         this.errorType = errorType;
         this.timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         this.className = className;

--- a/src/main/java/com/guarino/literaspringapi/shared/exception/ResourceAlreadyExistsException.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/exception/ResourceAlreadyExistsException.java
@@ -5,8 +5,4 @@ public class ResourceAlreadyExistsException extends RuntimeException {
     public ResourceAlreadyExistsException(String resourceName, String fieldName, Object fieldValue) {
         super(String.format("%s com %s '%s' já existe no sistema.", resourceName, fieldName, fieldValue));
     }
-
-    public ResourceAlreadyExistsException(String resourceName, String fieldName) {
-        super(String.format("%s com %s já existe no sistema.", resourceName, fieldName));
-    }
 }

--- a/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
@@ -30,7 +30,8 @@ public class GlobalExceptionHandler {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Erro de validação.",
                 "MethodArgumentNotValidException",
-                errorMessage.toString().trim()
+                errorMessage.toString().trim(),
+                "VALIDATION_ERROR"
         );
 
         return ResponseEntity
@@ -43,7 +44,8 @@ public class GlobalExceptionHandler {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Recurso já cadastrado.",
                 "ResourceAlreadyExistsException",
-                ex.getMessage()
+                ex.getMessage(),
+                "ALREADY_EXISTS_ERROR"
         );
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
@@ -2,11 +2,13 @@ package com.guarino.literaspringapi.shared.handler;
 
 import com.guarino.literaspringapi.shared.dto.ErrorResponseDTO;
 import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsException;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -61,7 +63,7 @@ public class GlobalExceptionHandler {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Erro de integridade de dados.",
                 ex.getClass().getSimpleName(),
-                List.of("A entrada fornecida contém invalidos ou potencialmente perigosos."),
+                List.of("A entrada fornecida contém dados inválidos ou potencialmente perigosos."),
                 "DATA_INTEGRITY_VIOLATION_ERROR"
         );
         return ResponseEntity
@@ -74,7 +76,6 @@ public class GlobalExceptionHandler {
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.toList());
     }
-
 }
 
 

--- a/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.guarino.literaspringapi.shared.handler;
 
 import com.guarino.literaspringapi.shared.dto.ErrorResponseDTO;
 import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -52,6 +53,19 @@ public class GlobalExceptionHandler {
         );
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponseDTO> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+                "Erro de integridade de dados.",
+                ex.getClass().getSimpleName(),
+                List.of("A entrada fornecida contém invalidos ou potencialmente perigosos."),
+                "DATA_INTEGRITY_VIOLATION_ERROR"
+        );
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
                 .body(errorResponse);
     }
     

--- a/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -18,19 +19,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleValidationExceptions(MethodArgumentNotValidException ex) {
 
         List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
-        StringBuilder errorMessage = new StringBuilder();
-
-        for (FieldError fieldError : fieldErrors) {
-            errorMessage.append(fieldError.getField())
-                    .append(": ")
-                    .append(fieldError.getDefaultMessage())
-                    .append("\n");
-        }
 
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Erro de validação.",
                 "MethodArgumentNotValidException",
-                errorMessage.toString().trim(),
+                getValidationMessages(fieldErrors).toString(),
                 "VALIDATION_ERROR"
         );
 
@@ -51,6 +44,13 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.BAD_REQUEST)
                 .body(errorResponse);
     }
+
+    private List<String> getValidationMessages(List<FieldError> fieldErrors) {
+        return fieldErrors.stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.toList());
+    }
+
 }
 
 

--- a/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Erro de validação.",
                 "MethodArgumentNotValidException",
-                getValidationMessages(fieldErrors).toString(),
+                getValidationMessages(fieldErrors),
                 "VALIDATION_ERROR"
         );
 
@@ -37,8 +37,8 @@ public class GlobalExceptionHandler {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Recurso já cadastrado.",
                 "ResourceAlreadyExistsException",
-                ex.getMessage(),
-                "ALREADY_EXISTS_ERROR"
+                List.of(ex.getMessage()),
+                "RESOURCE_EXISTS_ERROR"
         );
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/handler/GlobalExceptionHandler.java
@@ -17,16 +17,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDTO> handleValidationExceptions(MethodArgumentNotValidException ex) {
-
         List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
-
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
                 "Erro de validação.",
                 "MethodArgumentNotValidException",
                 getValidationMessages(fieldErrors),
                 "VALIDATION_ERROR"
         );
-
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(errorResponse);
@@ -35,7 +32,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResourceAlreadyExistsException.class)
     public ResponseEntity<ErrorResponseDTO> handleResourceAlreadyExistsException(ResourceAlreadyExistsException ex) {
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
-                "Recurso já cadastrado.",
+                "Error de cadastro duplicado.",
                 "ResourceAlreadyExistsException",
                 List.of(ex.getMessage()),
                 "RESOURCE_EXISTS_ERROR"
@@ -45,6 +42,19 @@ public class GlobalExceptionHandler {
                 .body(errorResponse);
     }
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDTO> handleGenericException(Exception ex) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+                "Erro interno no servidor.",
+                ex.getClass().getSimpleName(),
+                List.of("Ocorreu um erro inesperado. Por favor, entre em contato com o suporte."),
+                "GENERIC_SERVER_ERROR"
+        );
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse);
+    }
+    
     private List<String> getValidationMessages(List<FieldError> fieldErrors) {
         return fieldErrors.stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())

--- a/src/main/java/com/guarino/literaspringapi/shared/util/StringUtils.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/util/StringUtils.java
@@ -1,0 +1,16 @@
+package com.guarino.literaspringapi.shared.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class StringUtils {
+
+    public boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    public boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+}

--- a/src/main/java/com/guarino/literaspringapi/shared/util/StringUtils.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/util/StringUtils.java
@@ -5,12 +5,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class StringUtils {
 
-    public boolean isBlank(String value) {
-        return value == null || value.trim().isEmpty();
-    }
-
     public boolean isNotBlank(String value) {
         return value != null && !value.trim().isEmpty();
     }
-
 }

--- a/src/main/java/com/guarino/literaspringapi/shared/util/UniquenessValidator.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/util/UniquenessValidator.java
@@ -1,6 +1,7 @@
 package com.guarino.literaspringapi.shared.util;
 
 import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsException;
+
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -27,7 +28,6 @@ public class UniquenessValidator {
 
     private boolean isNotEmpty(Object value) {
         if (value == null) return false;
-
         if (value instanceof String s) {
             return StringUtils.isNotBlank(s);
         }

--- a/src/main/java/com/guarino/literaspringapi/shared/util/UniquenessValidator.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/util/UniquenessValidator.java
@@ -1,0 +1,36 @@
+package com.guarino.literaspringapi.shared.util;
+
+import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+@Component
+public class UniquenessValidator {
+
+    public record ValidationEntry(Object value, Predicate<Object> existsFunction) {}
+
+    public void validate(String entityName, Object value, Predicate<Object> existsFunction, String fieldName) {
+        if (isNotEmpty(value) && existsFunction.test(value)) {
+            throw new ResourceAlreadyExistsException(entityName, fieldName, value.toString());
+        }
+    }
+
+    public void validateMultiple(String entityName, Map<String, ValidationEntry> fields) {
+        for (Map.Entry<String, ValidationEntry> entry : fields.entrySet()) {
+            String fieldName = entry.getKey();
+            ValidationEntry validationEntry = entry.getValue();
+            validate(entityName, validationEntry.value(), validationEntry.existsFunction(), fieldName);
+        }
+    }
+
+    private boolean isNotEmpty(Object value) {
+        if (value == null) return false;
+
+        if (value instanceof String s) {
+            return StringUtils.isNotBlank(s);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/guarino/literaspringapi/shared/validation/CaseId.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/validation/CaseId.java
@@ -1,0 +1,12 @@
+package com.guarino.literaspringapi.shared.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CaseId {
+    String value();
+}

--- a/src/main/java/com/guarino/literaspringapi/shared/validation/TrimOnly.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/validation/TrimOnly.java
@@ -1,8 +1,8 @@
 package com.guarino.literaspringapi.shared.validation;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Target(ElementType.FIELD)

--- a/src/main/java/com/guarino/literaspringapi/shared/validation/TrimOnly.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/validation/TrimOnly.java
@@ -1,0 +1,10 @@
+package com.guarino.literaspringapi.shared.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrimOnly {}

--- a/src/main/java/com/guarino/literaspringapi/shared/validation/UpperTrim.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/validation/UpperTrim.java
@@ -1,0 +1,11 @@
+package com.guarino.literaspringapi.shared.validation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UpperTrim {}

--- a/src/main/java/com/guarino/literaspringapi/shared/validation/UpperTrim.java
+++ b/src/main/java/com/guarino/literaspringapi/shared/validation/UpperTrim.java
@@ -1,9 +1,8 @@
 package com.guarino.literaspringapi.shared.validation;
 
-
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Target(ElementType.FIELD)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,5 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+spring.devtools.restart.enabled=false

--- a/src/main/resources/db/migration/V2__update_table_publisher.sql
+++ b/src/main/resources/db/migration/V2__update_table_publisher.sql
@@ -1,0 +1,13 @@
+-- Adição de novas colunas
+ALTER TABLE publisher ADD COLUMN website VARCHAR(200);
+ALTER TABLE publisher ADD COLUMN tax_id VARCHAR(20);
+ALTER TABLE publisher ADD COLUMN telephone VARCHAR(15);
+
+-- Remoção de colunas
+ALTER TABLE publisher DROP COLUMN country_headquarter;
+
+-- Criação dos constraints unique
+ALTER TABLE publisher ADD CONSTRAINT unique_taxId UNIQUE (tax_id);
+ALTER TABLE publisher ADD CONSTRAINT unique_website UNIQUE (website);
+ALTER TABLE publisher ADD CONSTRAINT unique_telephone UNIQUE (telephone);
+ALTER TABLE publisher ADD CONSTRAINT unique_email UNIQUE (email);

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
@@ -2,42 +2,65 @@ package com.guarino.literaspringapi.application.publisher.service;
 
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
+import com.guarino.literaspringapi.shared.validation.CaseId;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class PublisherServiceIntegrationTest {
 
     @Autowired
     private PublisherService publisherService;
 
-    @Test
-    void shouldCreatePublisherWithTransformedFields() {
-        PublisherRequestDTO request = new PublisherRequestDTO(
-                "Editora Abril   ",
-                "1950-03-04",
-                "   A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
-                        "com publicações em diversos segmentos, incluindo revistas de notícias, " +
-                        "entretenimento e estilo de vida.   ",
-                "  contato@abril.com.br",
-                "https://www.abril.com.br  ",
-                " 02183757000193",
-                "1134567890 "
-        );
-        PublisherResponseDTO response = publisherService.createPublisher(request);
-        assertEquals("EDITORA ABRIL", response.name());
-        assertEquals("A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
-                "com publicações em diversos segmentos, incluindo revistas de notícias, " +
-                "entretenimento e estilo de vida.", response.description());
-        assertEquals("CONTATO@ABRIL.COM.BR", response.email());
-        assertEquals("HTTPS://WWW.ABRIL.COM.BR", response.website());
-        assertEquals("02183757000193", response.taxId());
-        assertEquals("1134567890", response.telephone());
+    private PublisherRequestDTO request;
+
+    @Nested
+    class CreatePublisher{
+
+        @BeforeEach
+        void setUp() {
+            request = new PublisherRequestDTO(
+                    "Editora Abril   ",
+                    "1950-03-04",
+                    "   A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                            "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                            "entretenimento e estilo de vida.   ",
+                    "  contato@abril.com.br",
+                    "https://www.abril.com.br  ",
+                    " 02183757000193",
+                    "1134567890 "
+            );
+        }
+
+        @Test
+        @DisplayName("Deve criar uma editora com campos transformados.")
+        @CaseId("CT-008")
+        void shouldCreatePublisherWithTransformedFields() {
+
+            PublisherResponseDTO response = publisherService.createPublisher(request);
+
+            assertEquals("EDITORA ABRIL", response.name());
+            assertEquals("A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                    "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                    "entretenimento e estilo de vida.", response.description());
+            assertEquals("CONTATO@ABRIL.COM.BR", response.email());
+            assertEquals("HTTPS://WWW.ABRIL.COM.BR", response.website());
+            assertEquals("02183757000193", response.taxId());
+            assertEquals("1134567890", response.telephone());
+            assertNotNull(response.idPublisher());
+        }
     }
 }

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.guarino.literaspringapi.application.publisher.service;
 
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,18 +20,26 @@ class PublisherServiceIntegrationTest {
     @Test
     void shouldCreatePublisherWithTransformedFields() {
         PublisherRequestDTO request = new PublisherRequestDTO(
-                " Nome da Editora ",
-                "2025-04-20",
-                "   Descrição válida.   ",
-                "email@dominio.com",
-                "https://www.google.com",
-                "123456789",
-                "12345678901234"
+                "Editora Abril   ",
+                "1950-03-04",
+                "   A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                        "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                        "entretenimento e estilo de vida.   ",
+                "  contato@abril.com.br",
+                "https://www.abril.com.br  ",
+                " 02183757000193",
+                "1134567890 "
         );
 
         PublisherResponseDTO response = publisherService.createPublisher(request);
 
-        assertEquals("NOME DA EDITORA", response.name());
-        assertEquals("Descrição válida.", response.description());
+        assertEquals("EDITORA ABRIL", response.name());
+        assertEquals("A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                "entretenimento e estilo de vida.", response.description());
+        assertEquals("CONTATO@ABRIL.COM.BR", response.email());
+        assertEquals("HTTPS://WWW.ABRIL.COM.BR", response.website());
+        assertEquals("02183757000193", response.taxId());
+        assertEquals("1134567890", response.telephone());
     }
 }

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
@@ -30,9 +30,7 @@ class PublisherServiceIntegrationTest {
                 " 02183757000193",
                 "1134567890 "
         );
-
         PublisherResponseDTO response = publisherService.createPublisher(request);
-
         assertEquals("EDITORA ABRIL", response.name());
         assertEquals("A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
                 "com publicações em diversos segmentos, incluindo revistas de notícias, " +

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceIntegrationTest.java
@@ -1,0 +1,36 @@
+package com.guarino.literaspringapi.application.publisher.service;
+
+import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
+import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PublisherServiceIntegrationTest {
+
+    @Autowired
+    private PublisherService publisherService;
+
+    @Test
+    void shouldCreatePublisherWithTransformedFields() {
+        PublisherRequestDTO request = new PublisherRequestDTO(
+                " Nome da Editora ",
+                "2025-04-20",
+                "   Descrição válida.   ",
+                "email@dominio.com",
+                "https://www.google.com",
+                "123456789",
+                "12345678901234"
+        );
+
+        PublisherResponseDTO response = publisherService.createPublisher(request);
+
+        assertEquals("NOME DA EDITORA", response.name());
+        assertEquals("Descrição válida.", response.description());
+    }
+}

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -55,7 +55,6 @@ class PublisherServiceTest {
                 "123456789",
                 "12345678901234"
         );
-
         publisher = new Publisher(
                 "NOME DA EDITORA",
                 "2025-04-20",
@@ -65,9 +64,7 @@ class PublisherServiceTest {
                 "123456789",
                 "12345678901234"
         );
-
         uuid = UUID.randomUUID().toString();
-
         response = new PublisherResponseDTO(
                 uuid,
                 "NOME DA EDITORA",
@@ -78,7 +75,6 @@ class PublisherServiceTest {
                 "123456789",
                 "12345678901234"
         );
-
     }
 
     @Nested
@@ -87,7 +83,6 @@ class PublisherServiceTest {
         @Test
         @DisplayName("Deve criar a editora quando todos os campos forem válidos.")
         void shouldCreatePublisherWhenAllFieldsAreValid(){
-
             when(publisherMapper.toEntity(request)).thenReturn(publisher);
             when(publisherRepository.save(any(Publisher.class))).thenAnswer(invocation -> {
                 Publisher publisherToSave = invocation.getArgument(0);
@@ -95,34 +90,27 @@ class PublisherServiceTest {
                 return publisherToSave;
             });
             when(publisherMapper.toResponseDTO(publisher)).thenReturn(response);
-
             PublisherResponseDTO result = publisherService.createPublisher(request);
-
             assertNotNull(result);
             assertEquals(response.name(), result.name());
             assertEquals(response.email(), result.email());
             verify(publisherRepository, times(1)).save(publisher);
             verify(publisherMapper, times(1)).toEntity(request);
             verify(publisherMapper, times(1)).toResponseDTO(publisher);
-
         }
 
         @Test
         @DisplayName("Deve lançar uma exceção de recurso já existente quando o e-mail do editor for duplicado.")
         void shouldThrowResourceAlreadyExistsExceptionWhenPublisherEmailIsDuplicated() {
             when(publisherMapper.toEntity(request)).thenReturn(publisher);
-
             doThrow(new ResourceAlreadyExistsException("Editora", "email", request.getEmail()))
                     .when(uniquenessValidator).validateMultiple(anyString(), anyMap());
-
             assertThrows(ResourceAlreadyExistsException.class, () ->
                     publisherService.createPublisher(request)
             );
-
             verify(publisherMapper, times(1)).toEntity(request);
             verify(uniquenessValidator, times(1)).validateMultiple(anyString(), anyMap());
             verify(publisherRepository, times(0)).save(any(Publisher.class));
         }
-        
     }
 }

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -7,6 +7,11 @@ import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
 import com.guarino.literaspringapi.domain.publisher.repository.PublisherRepository;
 import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsException;
 import com.guarino.literaspringapi.shared.util.UniquenessValidator;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,9 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.UUID;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -121,6 +121,6 @@ class PublisherServiceTest {
             verify(uniquenessValidator, times(1)).validateMultiple(anyString(), anyMap());
             verify(publisherRepository, times(0)).save(any(Publisher.class));
         }
-
+        
     }
 }

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -97,6 +97,8 @@ class PublisherServiceTest {
             assertEquals(response.name(), result.name());
             assertEquals(response.email(), result.email());
             verify(publisherRepository, times(1)).save(publisher);
+            verify(publisherMapper, times(1)).toEntity(request);
+            verify(publisherMapper, times(1)).toResponseDTO(publisher);
 
         }
 

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -1,0 +1,106 @@
+package com.guarino.literaspringapi.application.publisher.service;
+
+import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
+import com.guarino.literaspringapi.application.publisher.dto.PublisherResponseDTO;
+import com.guarino.literaspringapi.application.publisher.mapper.PublisherMapper;
+import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
+import com.guarino.literaspringapi.domain.publisher.repository.PublisherRepository;
+import com.guarino.literaspringapi.shared.util.UniquenessValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PublisherServiceTest {
+
+    @Mock
+    private PublisherRepository publisherRepository;
+    @Mock
+    private PublisherMapper publisherMapper;
+    @Mock
+    private UniquenessValidator uniquenessValidator;
+
+    @InjectMocks
+    private PublisherService publisherService;
+
+    private Publisher publisher;
+    private PublisherRequestDTO request;
+    private PublisherResponseDTO response;
+    private String uuid;
+
+    @BeforeEach
+    void setUp() {
+        request = new PublisherRequestDTO(
+                "Nome da Editora",
+                "2025-04-20",
+                "Uma descrição.",
+                "email@dominio.com",
+                "https://google.com",
+                "123456789",
+                "12345678901234"
+        );
+
+        publisher = new Publisher(
+                "NOME DA EDITORA",
+                "2025-04-20",
+                "Uma descrição.",
+                "EMAIL@DOMINIO.COM",
+                "HTTPS://GOOGLE.COM",
+                "123456789",
+                "12345678901234"
+        );
+
+        uuid = UUID.randomUUID().toString();
+
+        response = new PublisherResponseDTO(
+                uuid,
+                "NOME DA EDITORA",
+                "2025-04-20",
+                "Uma descrição.",
+                "EMAIL@DOMINIO.COM",
+                "HTTPS://GOOGLE.COM",
+                "123456789",
+                "12345678901234"
+        );
+
+    }
+
+    @Nested
+    class CreatePublisher{
+        @Test
+        @DisplayName("Deve criar a editora quando todos os campos forem válidos.")
+        void shouldCreatePublisherWhenAllFieldsAreValid(){
+
+            when(publisherMapper.toEntity(request)).thenReturn(publisher);
+            when(publisherRepository.save(any(Publisher.class))).thenAnswer(invocation -> {
+                Publisher publisherToSave = invocation.getArgument(0);
+                publisherToSave.setIdPublisher(UUID.fromString(uuid));
+                return publisherToSave;
+            });
+            when(publisherMapper.toResponseDTO(publisher)).thenReturn(response);
+
+            PublisherResponseDTO result = publisherService.createPublisher(request);
+
+            assertNotNull(result);
+            assertEquals(response.name(), result.name());
+            assertEquals(response.email(), result.email());
+            verify(publisherRepository, times(1)).save(publisher);
+
+        }
+
+
+
+    }
+}

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -7,6 +7,7 @@ import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
 import com.guarino.literaspringapi.domain.publisher.repository.PublisherRepository;
 import com.guarino.literaspringapi.shared.exception.ResourceAlreadyExistsException;
 import com.guarino.literaspringapi.shared.util.UniquenessValidator;
+import com.guarino.literaspringapi.shared.validation.CaseId;
 
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@Transactional
 class PublisherServiceTest {
 
     @Mock
@@ -82,6 +85,7 @@ class PublisherServiceTest {
 
         @Test
         @DisplayName("Deve criar a editora quando todos os campos forem válidos.")
+        @CaseId("CT-001")
         void shouldCreatePublisherWhenAllFieldsAreValid(){
             when(publisherMapper.toEntity(request)).thenReturn(publisher);
             when(publisherRepository.save(any(Publisher.class))).thenAnswer(invocation -> {
@@ -101,6 +105,7 @@ class PublisherServiceTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de recurso já existente quando o e-mail do editor for duplicado.")
+        @CaseId("CT-002")
         void shouldThrowResourceAlreadyExistsExceptionWhenPublisherEmailIsDuplicated() {
             when(publisherMapper.toEntity(request)).thenReturn(publisher);
             doThrow(new ResourceAlreadyExistsException("Editora", "email", request.getEmail()))

--- a/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
+++ b/src/test/java/com/guarino/literaspringapi/application/publisher/service/PublisherServiceTest.java
@@ -106,8 +106,8 @@ class PublisherServiceTest {
         }
 
         @Test
-        @DisplayName("Deve lançar exceção quando o cadastro for duplicado")
-        void shouldThrowExceptionWhenPublisherExists() {
+        @DisplayName("Deve lançar uma exceção de recurso já existente quando o e-mail do editor for duplicado.")
+        void shouldThrowResourceAlreadyExistsExceptionWhenPublisherEmailIsDuplicated() {
             when(publisherMapper.toEntity(request)).thenReturn(publisher);
 
             doThrow(new ResourceAlreadyExistsException("Editora", "email", request.getEmail()))

--- a/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
@@ -22,20 +22,28 @@ class FieldTransformationAspectIntegrationTest {
     @DisplayName("Deve transformar campos antes de entidade.")
     void shouldTransformFieldsBeforeToEntity() {
         PublisherRequestDTO request = new PublisherRequestDTO(
-                " Nome da Editora ",
-                "2025-04-20",
-                "   Descrição válida.   ",
-                "email@dominio.com",
-                "https://www.google.com",
-                "123456789",
-                "12345678901234"
+                "Editora Abril   ",
+                "1950-03-04",
+                "   A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                        "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                        "entretenimento e estilo de vida.   ",
+                "  contato@abril.com.br",
+                "https://www.abril.com.br  ",
+                " 02183757000193",
+                "1134567890 "
         );
 
         Publisher publisher = publisherMapper.toEntity(request);
 
-        // Verificando a transformação dos campos
-        assertEquals("NOME DA EDITORA", publisher.getName()); // O nome deve ser uppercased
-        assertEquals("Descrição válida.", publisher.getDescription()); // A descrição deve ser trimada
+        assertEquals("EDITORA ABRIL", publisher.getName());
+        assertEquals("A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                "entretenimento e estilo de vida.", publisher.getDescription());
+        assertEquals("CONTATO@ABRIL.COM.BR", publisher.getEmail());
+        assertEquals("HTTPS://WWW.ABRIL.COM.BR", publisher.getWebsite());
+        assertEquals("02183757000193", publisher.getTaxId());
+        assertEquals("1134567890", publisher.getTelephone());
+
     }
 }
 

--- a/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
@@ -4,25 +4,30 @@ import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO
 import com.guarino.literaspringapi.application.publisher.mapper.PublisherMapper;
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
 
+import com.guarino.literaspringapi.shared.validation.CaseId;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Transactional
 class FieldTransformationAspectIntegrationTest {
 
     @Autowired
     private PublisherMapper publisherMapper;
 
-    @Test
-    @DisplayName("Deve transformar campos antes de entidade.")
-    void shouldTransformFieldsBeforeToEntity() {
-        PublisherRequestDTO request = new PublisherRequestDTO(
+    private PublisherRequestDTO request;
+
+    @BeforeEach
+    void setUp() {
+        request = new PublisherRequestDTO(
                 "Editora Abril   ",
                 "1950-03-04",
                 "   A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
@@ -33,9 +38,13 @@ class FieldTransformationAspectIntegrationTest {
                 " 02183757000193",
                 "1134567890 "
         );
+    }
 
+    @Test
+    @DisplayName("Deve transformar campos antes de entidade.")
+    @CaseId("CT-009")
+    void shouldTransformFieldsBeforeToEntity() {
         Publisher publisher = publisherMapper.toEntity(request);
-
         assertEquals("EDITORA ABRIL", publisher.getName());
         assertEquals("A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
                 "com publicações em diversos segmentos, incluindo revistas de notícias, " +
@@ -44,7 +53,6 @@ class FieldTransformationAspectIntegrationTest {
         assertEquals("HTTPS://WWW.ABRIL.COM.BR", publisher.getWebsite());
         assertEquals("02183757000193", publisher.getTaxId());
         assertEquals("1134567890", publisher.getTelephone());
-
     }
 }
 

--- a/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
@@ -3,6 +3,7 @@ package com.guarino.literaspringapi.config.aop;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.mapper.PublisherMapper;
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/config/aop/FieldTransformationAspectIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.guarino.literaspringapi.config.aop;
+
+import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
+import com.guarino.literaspringapi.application.publisher.mapper.PublisherMapper;
+import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class FieldTransformationAspectIntegrationTest {
+
+    @Autowired
+    private PublisherMapper publisherMapper;
+
+    @Test
+    @DisplayName("Deve transformar campos antes de entidade.")
+    void shouldTransformFieldsBeforeToEntity() {
+        PublisherRequestDTO request = new PublisherRequestDTO(
+                " Nome da Editora ",
+                "2025-04-20",
+                "   Descrição válida.   ",
+                "email@dominio.com",
+                "https://www.google.com",
+                "123456789",
+                "12345678901234"
+        );
+
+        Publisher publisher = publisherMapper.toEntity(request);
+
+        // Verificando a transformação dos campos
+        assertEquals("NOME DA EDITORA", publisher.getName()); // O nome deve ser uppercased
+        assertEquals("Descrição válida.", publisher.getDescription()); // A descrição deve ser trimada
+    }
+}
+

--- a/src/test/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepositoryIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepositoryIntegrationTest.java
@@ -1,17 +1,19 @@
 package com.guarino.literaspringapi.domain.publisher.repository;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
-import jakarta.transaction.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -35,31 +37,36 @@ class PublisherRepositoryIntegrationTest {
     @Autowired
     private PublisherRepository publisherRepository;
 
+    private PublisherRequestDTO request;
+
+    @BeforeEach
+    void setUp() {
+        request = new PublisherRequestDTO(
+                "Editora Abril",
+                "1950-03-04",
+                "A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                        "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                        "entretenimento e estilo de vida.",
+                "contato@abril.com.br",
+                "https://www.abril.com.br",
+                "02183757000193",
+                "1134567890"
+        );
+    }
+
     @Test
     @DisplayName("Deve persistir o texto perigoso no banco sem executar comandos maliciosos")
     void shouldSaveMaliciousTextAsPlainString() throws Exception {
-        String maliciousName = "Nome da Editora'; DROP TABLE publisher; --";
-        PublisherRequestDTO request = new PublisherRequestDTO(
-                maliciousName,
-                "2025-04-20",
-                "Descrição válida.",
-                "email@dominio.com",
-                "https://www.google.com",
-                "123456789",
-                "12345678901234"
-        );
-
+        String maliciousData = "Editora Abril; DROP TABLE publisher; --";
+        request.setName(maliciousData);
         mockMvc.perform(post("/api/publisher")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated());
-
         List<Publisher> allPublishers = publisherRepository.findAll();
         assertFalse(allPublishers.isEmpty());
-
         boolean found = allPublishers.stream()
-                .anyMatch(p -> p.getName().equalsIgnoreCase(maliciousName));
-
+                .anyMatch(p -> p.getName().equalsIgnoreCase(maliciousData));
         assertTrue(found, "O nome com SQL Injection deveria ter sido salvo como texto normal.");
     }
 }

--- a/src/test/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepositoryIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepositoryIntegrationTest.java
@@ -1,9 +1,8 @@
-package com.guarino.literaspringapi.integration;
+package com.guarino.literaspringapi.domain.publisher.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
-import com.guarino.literaspringapi.domain.publisher.repository.PublisherRepository;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,10 +22,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureMockMvc
-@TestPropertySource(locations = "classpath:application-test.properties")
-@Transactional
-class PublisherIntegrationTest {
+class PublisherRepositoryIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepositoryIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/domain/publisher/repository/PublisherRepositoryIntegrationTest.java
@@ -2,20 +2,22 @@ package com.guarino.literaspringapi.domain.publisher.repository;
 
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
+import com.guarino.literaspringapi.shared.validation.CaseId;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.guarino.literaspringapi.shared.validation.CaseId;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
-
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.MediaType;
 
 import java.util.List;
 

--- a/src/test/java/com/guarino/literaspringapi/integration/PublisherIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/integration/PublisherIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.guarino.literaspringapi.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
+import com.guarino.literaspringapi.domain.publisher.entity.Publisher;
+import com.guarino.literaspringapi.domain.publisher.repository.PublisherRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.properties")
+@Transactional
+class PublisherIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PublisherRepository publisherRepository;
+
+    @Test
+    @DisplayName("Deve persistir o texto perigoso no banco sem executar comandos maliciosos")
+    void shouldSaveMaliciousTextAsPlainString() throws Exception {
+        String maliciousName = "Nome da Editora'; DROP TABLE publisher; --";
+        PublisherRequestDTO request = new PublisherRequestDTO(
+                maliciousName,
+                "2025-04-20",
+                "Descrição válida.",
+                "email@dominio.com",
+                "https://www.google.com",
+                "123456789",
+                "12345678901234"
+        );
+
+        mockMvc.perform(post("/api/publisher")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        List<Publisher> allPublishers = publisherRepository.findAll();
+        assertFalse(allPublishers.isEmpty());
+
+        boolean found = allPublishers.stream()
+                .anyMatch(p -> p.getName().equalsIgnoreCase(maliciousName));
+
+        assertTrue(found, "O nome com SQL Injection deveria ter sido salvo como texto normal.");
+    }
+}
+

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -3,11 +3,14 @@ package com.guarino.literaspringapi.presentation.publisher.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.service.PublisherService;
+
+import org.mockito.Mockito;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -65,7 +68,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando o nome for vazio")
         void shouldThrowValidationExceptionWhenNameIsEmpty() throws Exception {
             request.setName("");
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -79,7 +81,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando email for nulo")
         void shouldThrowValidationExceptionWhenNameIsNull() throws Exception {
             request.setName(null);
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -93,7 +94,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando o nome tiver menos de 3 caracteres.")
         void shouldThrowValidationExceptionWhenNameHasLessThanThreeCharacters() throws Exception {
             request.setName("S3");
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -107,7 +107,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando data não tiver a formação desejada.")
         void shouldThrowValidationExceptionWhenDateFormatIsInvalid() throws Exception {
             request.setFoundationDate("25-10-2025");
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -121,7 +120,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando telefone tiver mais de 15 caracteres.")
         void shouldThrowValidationExceptionWhenPhoneNumberExceedsMaxLength() throws Exception {
             request.setTelephone("1234567891234567891");
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -135,7 +133,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando o e-mail for inválido")
         void shouldThrowValidationExceptionWhenEmailIsInvalid() throws Exception {
             request.setEmail("emaildominio.com");
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -148,7 +145,6 @@ class PublisherControllerIntegrationTest {
         @DisplayName("Deve lançar uma exceção de validação quando telefone tiver caracteres diferentes de números.")
         void shouldThrowValidationExceptionWhenPhoneNumberHasNonNumericCharacters() throws Exception {
             request.setTelephone("125-548");
-
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -161,19 +157,10 @@ class PublisherControllerIntegrationTest {
         @Test
         @DisplayName("Deve aceitar input suspeito sem executar SQL malicioso")
         void shouldTreatSqlInjectionLikeNormalTextAndCreateEntity() throws Exception {
-            PublisherRequestDTO requestWithMaliciousSQL = new PublisherRequestDTO(
-                    "Nome da Editora'; DROP TABLE publisher; --",
-                    "2025-04-20",
-                    "Descrição válida.",
-                    "email@dominio.com",
-                    "www.google.com",
-                    "123456789",
-                    "12345678901234"
-            );
-
+            request.setName("Nome da Editora'; DROP TABLE publisher; --");
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestWithMaliciousSQL)))
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isCreated());
         }
     }

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.guarino.literaspringapi.presentation.publisher.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.service.PublisherService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,8 @@ class PublisherControllerIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    private PublisherRequestDTO request;
+
     @TestConfiguration
     static class MockConfig {
         @Bean
@@ -39,21 +42,29 @@ class PublisherControllerIntegrationTest {
         }
     }
 
+    @BeforeEach
+    void setUp() {
+        request = new PublisherRequestDTO(
+                "Editora Abril",
+                "1950-03-04",
+                "A Editora Abril é uma das maiores editoras de revistas do Brasil, " +
+                        "com publicações em diversos segmentos, incluindo revistas de notícias, " +
+                        "entretenimento e estilo de vida.",
+                "contato@abril.com.br",
+                "https://www.abril.com.br",
+                "02183757000193",
+                "1134567890"
+        );
+
+    }
+
     @Nested
     class CreatePublisher{
 
         @Test
-        @DisplayName("Deve lançar uma exceção de validação quando o nome for nulo ou vazio")
-        void shouldThrowValidationExceptionWhenNameIsNullOrEmpty() throws Exception {
-            PublisherRequestDTO request = new PublisherRequestDTO(
-                    "",
-                    "2025-04-20",
-                    "Descrição válida.",
-                    "email@dominio.com",
-                    "https://www.google.com",
-                    "123456789",
-                    "12345678901234"
-            );
+        @DisplayName("Deve lançar uma exceção de validação quando o nome for vazio")
+        void shouldThrowValidationExceptionWhenNameIsEmpty() throws Exception {
+            request.setName("");
 
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -65,24 +76,86 @@ class PublisherControllerIntegrationTest {
         }
 
         @Test
-        @DisplayName("Deve lançar uma exceção de validação quando o e-mail for inválido")
-        void shouldThrowValidationExceptionWhenEmailIsInvalid() throws Exception {
-            PublisherRequestDTO requestWithInvalidEmail = new PublisherRequestDTO(
-                    "Nome da Editora",
-                    "2025-04-20",
-                    "Descrição válida.",
-                    "email-inválido",  // Email inválido
-                    "https://www.google.com",
-                    "123456789",
-                    "12345678901234"
-            );
+        @DisplayName("Deve lançar uma exceção de validação quando email for nulo")
+        void shouldThrowValidationExceptionWhenNameIsNull() throws Exception {
+            request.setName(null);
 
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(requestWithInvalidEmail)))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages").isArray())
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*nome.*/i)]").exists());
+        }
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando o nome tiver menos de 3 caracteres.")
+        void shouldThrowValidationExceptionWhenNameHasLessThanThreeCharacters() throws Exception {
+            request.setName("S3");
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages").isArray())
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*nome.*/i)]").exists());
+        }
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando data não tiver a formação desejada.")
+        void shouldThrowValidationExceptionWhenDateFormatIsInvalid() throws Exception {
+            request.setFoundationDate("25-10-2025");
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages").isArray())
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*foundationDate.*/i)]").exists());
+        }
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando telefone tiver mais de 15 caracteres.")
+        void shouldThrowValidationExceptionWhenPhoneNumberExceedsMaxLength() throws Exception {
+            request.setTelephone("1234567891234567891");
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages").isArray())
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*telephone.*/i)]").exists());
+        }
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando o e-mail for inválido")
+        void shouldThrowValidationExceptionWhenEmailIsInvalid() throws Exception {
+            request.setEmail("emaildominio.com");
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.errorType").value("Erro de validação."))
                     .andExpect(jsonPath("$.messages[?(@ =~ /.*email.*/i)]").exists());
+        }
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando telefone tiver caracteres diferentes de números.")
+        void shouldThrowValidationExceptionWhenPhoneNumberHasNonNumericCharacters() throws Exception {
+            request.setTelephone("125-548");
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages").isArray())
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*telephone.*/i)]").exists());
         }
 
         @Test

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,8 +22,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-@WebMvcTest(PublisherController.class)
-@Import(PublisherControllerIntegrationTest.MockConfig.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
 class PublisherControllerIntegrationTest {

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -58,7 +58,6 @@ class PublisherControllerIntegrationTest {
                 "02183757000193",
                 "1134567890"
         );
-
     }
 
     @Nested

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -131,7 +131,7 @@ class PublisherControllerIntegrationTest {
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando o e-mail for inválido")
         void shouldThrowValidationExceptionWhenEmailIsInvalid() throws Exception {
-            request.setEmail("emaildominio.com");
+            request.setEmail("email.dom.com");
             mockMvc.perform(post("/api/publisher")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -20,8 +21,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(PublisherController.class)
-@Import(PublisherControllerTest.MockConfig.class)
-class PublisherControllerTest {
+@Import(PublisherControllerIntegrationTest.MockConfig.class)
+@ActiveProfiles("test")
+class PublisherControllerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerIntegrationTest.java
@@ -4,12 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
 import com.guarino.literaspringapi.application.publisher.service.PublisherService;
 
+import com.guarino.literaspringapi.shared.validation.CaseId;
+import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,6 +16,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -27,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(PublisherController.class)
 @Import(PublisherControllerIntegrationTest.MockConfig.class)
 @ActiveProfiles("test")
+@Transactional
 class PublisherControllerIntegrationTest {
 
     @Autowired
@@ -65,6 +64,7 @@ class PublisherControllerIntegrationTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando o nome for vazio")
+        @CaseId("CT-003")
         void shouldThrowValidationExceptionWhenNameIsEmpty() throws Exception {
             request.setName("");
             mockMvc.perform(post("/api/publisher")
@@ -77,7 +77,8 @@ class PublisherControllerIntegrationTest {
         }
 
         @Test
-        @DisplayName("Deve lançar uma exceção de validação quando email for nulo")
+        @DisplayName("Deve lançar uma exceção de validação quando nome for nulo")
+        @CaseId("CT-010")
         void shouldThrowValidationExceptionWhenNameIsNull() throws Exception {
             request.setName(null);
             mockMvc.perform(post("/api/publisher")
@@ -91,6 +92,7 @@ class PublisherControllerIntegrationTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando o nome tiver menos de 3 caracteres.")
+        @CaseId("CT-011")
         void shouldThrowValidationExceptionWhenNameHasLessThanThreeCharacters() throws Exception {
             request.setName("S3");
             mockMvc.perform(post("/api/publisher")
@@ -104,6 +106,7 @@ class PublisherControllerIntegrationTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando data não tiver a formação desejada.")
+        @CaseId("CT-007")
         void shouldThrowValidationExceptionWhenDateFormatIsInvalid() throws Exception {
             request.setFoundationDate("25-10-2025");
             mockMvc.perform(post("/api/publisher")
@@ -117,6 +120,7 @@ class PublisherControllerIntegrationTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando telefone tiver mais de 15 caracteres.")
+        @CaseId("CT-005")
         void shouldThrowValidationExceptionWhenPhoneNumberExceedsMaxLength() throws Exception {
             request.setTelephone("1234567891234567891");
             mockMvc.perform(post("/api/publisher")
@@ -130,6 +134,7 @@ class PublisherControllerIntegrationTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando o e-mail for inválido")
+        @CaseId("CT-004")
         void shouldThrowValidationExceptionWhenEmailIsInvalid() throws Exception {
             request.setEmail("email.dom.com");
             mockMvc.perform(post("/api/publisher")
@@ -142,6 +147,7 @@ class PublisherControllerIntegrationTest {
 
         @Test
         @DisplayName("Deve lançar uma exceção de validação quando telefone tiver caracteres diferentes de números.")
+        @CaseId("CT-012")
         void shouldThrowValidationExceptionWhenPhoneNumberHasNonNumericCharacters() throws Exception {
             request.setTelephone("125-548");
             mockMvc.perform(post("/api/publisher")
@@ -153,8 +159,14 @@ class PublisherControllerIntegrationTest {
                     .andExpect(jsonPath("$.messages[?(@ =~ /.*telephone.*/i)]").exists());
         }
 
+    }
+
+    @Nested
+    class SqlInjectionTest{
+
         @Test
         @DisplayName("Deve aceitar input suspeito sem executar SQL malicioso")
+        @CaseId("CT-013")
         void shouldTreatSqlInjectionLikeNormalTextAndCreateEntity() throws Exception {
             request.setName("Nome da Editora'; DROP TABLE publisher; --");
             mockMvc.perform(post("/api/publisher")

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerTest.java
@@ -82,6 +82,25 @@ class PublisherControllerTest {
                     .andExpect(jsonPath("$.errorType").value("Erro de validação."))
                     .andExpect(jsonPath("$.messages[?(@ =~ /.*email.*/i)]").exists());
         }
+
+        @Test
+        @DisplayName("Deve aceitar input suspeito sem executar SQL malicioso")
+        void shouldTreatSqlInjectionLikeNormalTextAndCreateEntity() throws Exception {
+            PublisherRequestDTO requestWithMaliciousSQL = new PublisherRequestDTO(
+                    "Nome da Editora'; DROP TABLE publisher; --",
+                    "2025-04-20",
+                    "Descrição válida.",
+                    "email@dominio.com",
+                    "www.google.com",
+                    "123456789",
+                    "12345678901234"
+            );
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestWithMaliciousSQL)))
+                    .andExpect(status().isCreated());
+        }
     }
 }
 

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerTest.java
@@ -1,0 +1,66 @@
+package com.guarino.literaspringapi.presentation.publisher.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guarino.literaspringapi.application.publisher.dto.PublisherRequestDTO;
+import com.guarino.literaspringapi.application.publisher.service.PublisherService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(PublisherController.class)
+@Import(PublisherControllerTest.MockConfig.class)
+class PublisherControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @TestConfiguration
+    static class MockConfig {
+        @Bean
+        public PublisherService publisherService() {
+            return Mockito.mock(PublisherService.class);
+        }
+    }
+
+    @Nested
+    class CreatePublisher{
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando o nome for nulo ou vazio")
+        void shouldThrowValidationExceptionWhenNameIsNullOrEmpty() throws Exception {
+            PublisherRequestDTO request = new PublisherRequestDTO(
+                    "",
+                    "2025-04-20",
+                    "Descrição válida.",
+                    "email@dominio.com",
+                    "https://www.google.com",
+                    "123456789",
+                    "12345678901234"
+            );
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages").isArray())
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*nome.*/i)]").exists());
+        }
+    }
+}
+

--- a/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerTest.java
+++ b/src/test/java/com/guarino/literaspringapi/presentation/publisher/controller/PublisherControllerTest.java
@@ -61,6 +61,27 @@ class PublisherControllerTest {
                     .andExpect(jsonPath("$.messages").isArray())
                     .andExpect(jsonPath("$.messages[?(@ =~ /.*nome.*/i)]").exists());
         }
+
+        @Test
+        @DisplayName("Deve lançar uma exceção de validação quando o e-mail for inválido")
+        void shouldThrowValidationExceptionWhenEmailIsInvalid() throws Exception {
+            PublisherRequestDTO requestWithInvalidEmail = new PublisherRequestDTO(
+                    "Nome da Editora",
+                    "2025-04-20",
+                    "Descrição válida.",
+                    "email-inválido",  // Email inválido
+                    "https://www.google.com",
+                    "123456789",
+                    "12345678901234"
+            );
+
+            mockMvc.perform(post("/api/publisher")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestWithInvalidEmail)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorType").value("Erro de validação."))
+                    .andExpect(jsonPath("$.messages[?(@ =~ /.*email.*/i)]").exists());
+        }
     }
 }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -3,7 +3,7 @@ spring.datasource.username=
 spring.datasource.password=
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 
@@ -12,3 +12,10 @@ spring.flyway.baseline-on-migrate=true
 spring.flyway.clean-disabled=false
 spring.flyway.locations=classpath:db/migration
 spring.flyway.schemas=public
+logging.level.org.flywaydb.core=DEBUG
+
+logging.level.root=INFO
+logging.level.br.com.seu.pacote=DEBUG
+logging.level.org.springframework.web=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql=TRACE

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+spring.datasource.url=
+spring.datasource.username=
+spring.datasource.password=
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=false
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.schemas=public
+spring.flyway.baseline-on-migrate=true
+spring.flyway.clean-disabled=false
+
+spring.test.database.replace=none

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -3,14 +3,12 @@ spring.datasource.username=
 spring.datasource.password=
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 
 spring.flyway.enabled=true
-spring.flyway.locations=classpath:db/migration
-spring.flyway.schemas=public
 spring.flyway.baseline-on-migrate=true
 spring.flyway.clean-disabled=false
-
-spring.test.database.replace=none
+spring.flyway.locations=classpath:db/migration
+spring.flyway.schemas=public

--- a/src/test/resources/db/migration/V1__create_table_publisher.sql
+++ b/src/test/resources/db/migration/V1__create_table_publisher.sql
@@ -1,0 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE publisher (
+       id_publisher UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+       name VARCHAR(150) NOT NULL,
+       foundation_date VARCHAR(10),
+       description TEXT,
+       email VARCHAR(150),
+       country_headquarter VARCHAR(100) DEFAULT 'BRASIL'
+);

--- a/src/test/resources/db/migration/V2__update_table_publisher.sql
+++ b/src/test/resources/db/migration/V2__update_table_publisher.sql
@@ -1,0 +1,13 @@
+-- Adição de novas colunas
+ALTER TABLE publisher ADD COLUMN website VARCHAR(200);
+ALTER TABLE publisher ADD COLUMN tax_id VARCHAR(20);
+ALTER TABLE publisher ADD COLUMN telephone VARCHAR(15);
+
+-- Remoção de colunas
+ALTER TABLE publisher DROP COLUMN country_headquarter;
+
+-- Criação dos constraints unique
+ALTER TABLE publisher ADD CONSTRAINT unique_taxId UNIQUE (tax_id);
+ALTER TABLE publisher ADD CONSTRAINT unique_website UNIQUE (website);
+ALTER TABLE publisher ADD CONSTRAINT unique_telephone UNIQUE (telephone);
+ALTER TABLE publisher ADD CONSTRAINT unique_email UNIQUE (email);


### PR DESCRIPTION
## Descrição
Este PR implementa a funcionalidade de **Cadastrar Editora**. A funcionalidade permite a criação de novas editoras na aplicação LiteraSpring, incluindo as validações de campos e tratamento de exceções.
### Principais Alterações:
- Criação da rota POST /api/publisher para cadastrar uma nova editora.
- Implementação de validações para garantir que os dados da editora sejam consistentes (ex: nome, e-mail, telefone, etc.).
- Adição de testes automatizados para garantir que a criação da editora funciona corretamente.
